### PR TITLE
chore(ci): consolidate frontend build and deploy workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,14 +1,15 @@
 name: Build Frontend
 
 on:
-  push:
+  pull_request:
     branches: [main]
 
 permissions:
   contents: read
 
 jobs:
-  build-deploy:
+  build-upload:
+    if: ${{ github.actor != 'github-actions[bot]' }}
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/deploy_cloudflare.yml
+++ b/.github/workflows/deploy_cloudflare.yml
@@ -3,35 +3,77 @@ name: Deploy Frontend to Cloudflare Pages
 on:
   workflow_run:
     workflows: ["Build Frontend"]
-    types:
-      - completed
+    types: [completed]
+
+  release:
+    types: [published]
 
 permissions:
-  contents: read
+  contents: write
+  id-token: write
+  actions: read
 
 jobs:
-  deploy:
+  deploy-preview:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
+      - name: Checkout main
         uses: actions/checkout@v4
-
-      - name: Download build artifact from latest build
-        uses: dawidd6/action-download-artifact@v6
         with:
-          workflow: build.yml
+          ref: main
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
           name: frontend-build
           path: ./dist
-          workflow_conclusion: success
-          branch: main
 
       - name: Verify artifact
         run: |
           test -f ./dist/index.html
 
-      - name: Deploy to Cloudflare Pages
+      - name: Generate temporary branch for Preview
+        run: |
+          TEMP_BRANCH="preview/${GITHUB_RUN_ID}"
+          git checkout -v "$TEMP_BRANCH"
+          git push origin "$TEMP_BRANCH"
+
+      - name: Deploy to Cloudflare Pages (Preview)
+        uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: romweb-frontend
+          directory: ./dist
+          branch: $TEMP_BRANCH
+          wranglerVersion: 2
+
+      - name: Clean up temporary branch
+        run: |
+          git push origin --delete "$TEMP_BRANCH"
+
+  deploy-prod:
+    if: ${{ github.event_name == 'release' && github.event.release.prerelease == false }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: frontend-build
+          path: ./dist
+
+      - name: Verify artifact
+        run: |
+          test -f ./dist/index.html
+
+      - name: Deploy to Cloudflare Pages (Production)
         uses: cloudflare/pages-action@v1
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -39,3 +81,4 @@ jobs:
           projectName: romweb-frontend
           directory: ./dist
           branch: main
+          wranglerVersion: 2


### PR DESCRIPTION
## Description:
This PR refactors the frontend CI/CD workflows to separate concerns and support both preview and production deployments:

### Changes:

- Build workflow (build.yml)
  - Triggered on PRs to main only.
  - Skips runs triggered by the GitHub Actions bot to avoid duplicate builds.
  - Generates a build artifact (frontend-build) usable by both preview and production deployments.

- Deploy workflow (deploy_cloudflare.yml)
  - Preview deployment:
    - Triggered after a successful build workflow.
    - Creates a temporary branch (preview/<GITHUB_RUN_ID>) for Cloudflare Pages to generate a preview URL.
    - Deletes the temporary branch after deployment.
  - Production deployment:
    - Triggered on published releases (prerelease: false).
    - Uses the same build artifact generated by the build workflow, ensuring consistency between preview and production.
  - Uses wranglerVersion: 2 for compatibility with the modern Cloudflare CLI.

### Benefits:
- Clear separation between build, preview, and production deploys.
- Prevents redundant builds for bot-generated PRs or release-please automation.
- Allows preview validation before merging to production.
- Simplifies future CI/CD maintenance and scalability.